### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ description = "Framework to create metaheuristics"
 repository = "https://github.com/DaPurr/Netaheuristics"
 
 [dependencies]
-rand = "0"
+rand = "0.8"
 assert_approx_eq = "1.1.0"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.